### PR TITLE
Add docker files to repo

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+# In the future, this should not be kept in the repo.
+# There's no sensitive data here right now, so it's okay to keep
+MONGODB_USER="user"
+MONGODB_PASSWORD="password"
+MONGODB_DATABASE="database"
+MONGODB_LOCAL_PORT=27106
+MONGODB_DOCKER_PORT=27107
+NODE_LOCAL_PORT=8080
+NODE_DOCKER_PORT=8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM amazoncorretto:17
+
+WORKDIR /app
+
+COPY target/backend-0.0.1-SNAPSHOT.jar backend-0.0.1-SNAPSHOT.jar
+
+ENTRYPOINT ["java","-jar","/app/backend-0.0.1-SNAPSHOT.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  app:
+    build: .
+    depends_on:
+      - mongodb
+    env_file: ./.env
+    environment:
+      - DB_HOST=mongodb
+      - DB_USER=$MONGODB_USER
+      - DB_PASSWORD=$MONGODB_PASSWORD
+      - DB_NAME=$MONGODB_DATABASE
+      - DB_PORT=$MONGODB_DOCKER_PORT
+    ports:
+      - $NODE_LOCAL_PORT:$NODE_DOCKER_PORT
+    restart: unless-stopped
+  mongodb:
+    env_file: ./.env
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=$MONGODB_USER
+      - MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD
+    image: mongo:5.0.2
+    ports:
+      - $MONGODB_LOCAL_PORT:$MONGODB_DOCKER_PORT
+    restart: unless-stopped
+    volumes:
+      - db:/data/db
+volumes:
+  db:


### PR DESCRIPTION
# Docker
I'm committing this as a branch instead of on the main repo because docker support isn't working currently. Both containers run, but they don't connect to eachother
You guys know more about mongo than I do, so hopefully you can get it connected.

Here's the output log currently:
```
[+] Running 2/0
 ✔ Container backend-mongodb-1  Created                                                                                                                                                                                               0.0s
 ✔ Container backend-app-1      Created                                                                                                                                                                                               0.0s
Attaching to backend-app-1, backend-mongodb-1
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.508+00:00"},"s":"I",  "c":"CONTROL",  "id":23285,   "ctx":"thread1","msg":"Automatically disabling TLS 1.0, to force-enable TLS 1.0 specify --sslDisabledProtocols 'none'"}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.510+00:00"},"s":"I",  "c":"NETWORK",  "id":4915701, "ctx":"thread1","msg":"Initialized wire specification","attr":{"spec":{"incomingExternalClient":{"minWireVersion":0,"maxWireVersion":13},"incomingInternalClient":{"minWireVersion":0,"maxWireVersion":13},"outgoing":{"minWireVersion":0,"maxWireVersion":13},"isInternalClient":true}}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.510+00:00"},"s":"W",  "c":"ASIO",     "id":22601,   "ctx":"thread1","msg":"No TransportLayer configured during NetworkInterface startup"}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.510+00:00"},"s":"I",  "c":"NETWORK",  "id":4648601, "ctx":"thread1","msg":"Implicit TCP FastOpen unavailable. If TCP FastOpen is required, set tcpFastOpenServer, tcpFastOpenClient, and tcpFastOpenQueueSize."}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.513+00:00"},"s":"W",  "c":"ASIO",     "id":22601,   "ctx":"thread1","msg":"No TransportLayer configured during NetworkInterface startup"}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.513+00:00"},"s":"I",  "c":"REPL",     "id":5123008, "ctx":"thread1","msg":"Successfully registered PrimaryOnlyService","attr":{"service":"TenantMigrationDonorService","ns":"config.tenantMigrationDonors"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.513+00:00"},"s":"I",  "c":"REPL",     "id":5123008, "ctx":"thread1","msg":"Successfully registered PrimaryOnlyService","attr":{"service":"TenantMigrationRecipientService","ns":"config.tenantMigrationRecipients"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.514+00:00"},"s":"I",  "c":"CONTROL",  "id":4615611, "ctx":"initandlisten","msg":"MongoDB starting","attr":{"pid":1,"port":27017,"dbPath":"/data/db","architecture":"64-bit","host":"551db17bce8a"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.515+00:00"},"s":"I",  "c":"CONTROL",  "id":23403,   "ctx":"initandlisten","msg":"Build Info","attr":{"buildInfo":{"version":"5.0.2","gitVersion":"6d9ec525e78465dcecadcff99cce953d380fedc8","openSSLVersion":"OpenSSL 1.1.1f  31 Mar 2020","modules":[],"allocator":"tcmalloc","environment":{"distmod":"ubuntu2004","distarch":"x86_64","target_arch":"x86_64"}}}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.515+00:00"},"s":"I",  "c":"CONTROL",  "id":51765,   "ctx":"initandlisten","msg":"Operating System","attr":{"os":{"name":"Ubuntu","version":"20.04"}}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.515+00:00"},"s":"I",  "c":"CONTROL",  "id":21951,   "ctx":"initandlisten","msg":"Options set by command line","attr":{"options":{"net":{"bindIp":"*"},"security":{"authorization":"enabled"}}}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.516+00:00"},"s":"I",  "c":"STORAGE",  "id":22270,   "ctx":"initandlisten","msg":"Storage engine to use detected by data files","attr":{"dbpath":"/data/db","storageEngine":"wiredTiger"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.516+00:00"},"s":"I",  "c":"STORAGE",  "id":22297,   "ctx":"initandlisten","msg":"Using the XFS filesystem is strongly recommended with the WiredTiger storage engine. See http://dochub.mongodb.org/core/prodnotes-filesystem","tags":["startupWarnings"]}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.516+00:00"},"s":"I",  "c":"STORAGE",  "id":22315,   "ctx":"initandlisten","msg":"Opening WiredTiger","attr":{"config":"create,cache_size=3346M,session_max=33000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),builtin_extension_config=(zstd=(compression_level=6)),file_manager=(close_idle_time=600,close_scan_interval=10,close_handle_minimum=250),statistics_log=(wait=0),verbose=[recovery_progress,checkpoint_progress,compact_progress],"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:31:59.981+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"initandlisten","msg":"WiredTiger message","attr":{"message":"[1680100319:981579][1:0x7fd64b83bc80], txn-recover: [WT_VERB_RECOVERY_PROGRESS] Recovering log 4 through 5"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.078+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"initandlisten","msg":"WiredTiger message","attr":{"message":"[1680100320:78022][1:0x7fd64b83bc80], txn-recover: [WT_VERB_RECOVERY_PROGRESS] Recovering log 5 through 5"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.183+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"initandlisten","msg":"WiredTiger message","attr":{"message":"[1680100320:183670][1:0x7fd64b83bc80], txn-recover: [WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS] Main recovery loop: starting at 4/10624 to 5/256"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.306+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"initandlisten","msg":"WiredTiger message","attr":{"message":"[1680100320:306845][1:0x7fd64b83bc80], txn-recover: [WT_VERB_RECOVERY_PROGRESS] Recovering log 4 through 5"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.373+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"initandlisten","msg":"WiredTiger message","attr":{"message":"[1680100320:373282][1:0x7fd64b83bc80], txn-recover: [WT_VERB_RECOVERY_PROGRESS] Recovering log 5 through 5"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.437+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"initandlisten","msg":"WiredTiger message","attr":{"message":"[1680100320:437112][1:0x7fd64b83bc80], txn-recover: [WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS] Set global recovery timestamp: (0, 0)"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.437+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"initandlisten","msg":"WiredTiger message","attr":{"message":"[1680100320:437153][1:0x7fd64b83bc80], txn-recover: [WT_VERB_RECOVERY | WT_VERB_RECOVERY_PROGRESS] Set global oldest timestamp: (0, 0)"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.441+00:00"},"s":"I",  "c":"STORAGE",  "id":22430,   "ctx":"initandlisten","msg":"WiredTiger message","attr":{"message":"[1680100320:441016][1:0x7fd64b83bc80], WT_SESSION.checkpoint: [WT_VERB_CHECKPOINT_PROGRESS] saving checkpoint snapshot min: 1, snapshot max: 1 snapshot count: 0, oldest timestamp: (0, 0) , meta checkpoint timestamp: (0, 0) base write gen: 48"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.459+00:00"},"s":"I",  "c":"STORAGE",  "id":4795906, "ctx":"initandlisten","msg":"WiredTiger opened","attr":{"durationMillis":943}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.459+00:00"},"s":"I",  "c":"RECOVERY", "id":23987,   "ctx":"initandlisten","msg":"WiredTiger recoveryTimestamp","attr":{"recoveryTimestamp":{"$timestamp":{"t":0,"i":0}}}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.461+00:00"},"s":"I",  "c":"STORAGE",  "id":4366408, "ctx":"initandlisten","msg":"No table logging settings modifications are required for existing WiredTiger tables","attr":{"loggingEnabled":true}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.465+00:00"},"s":"I",  "c":"STORAGE",  "id":22262,   "ctx":"initandlisten","msg":"Timestamp monitor starting"}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.475+00:00"},"s":"W",  "c":"CONTROL",  "id":22178,   "ctx":"initandlisten","msg":"/sys/kernel/mm/transparent_hugepage/enabled is 'always'. We suggest setting it to 'never'","tags":["startupWarnings"]}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.482+00:00"},"s":"I",  "c":"NETWORK",  "id":4915702, "ctx":"initandlisten","msg":"Updated wire specification","attr":{"oldSpec":{"incomingExternalClient":{"minWireVersion":0,"maxWireVersion":13},"incomingInternalClient":{"minWireVersion":0,"maxWireVersion":13},"outgoing":{"minWireVersion":0,"maxWireVersion":13},"isInternalClient":true},"newSpec":{"incomingExternalClient":{"minWireVersion":0,"maxWireVersion":13},"incomingInternalClient":{"minWireVersion":13,"maxWireVersion":13},"outgoing":{"minWireVersion":13,"maxWireVersion":13},"isInternalClient":true}}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.483+00:00"},"s":"I",  "c":"STORAGE",  "id":5071100, "ctx":"initandlisten","msg":"Clearing temp directory"}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.485+00:00"},"s":"I",  "c":"CONTROL",  "id":20536,   "ctx":"initandlisten","msg":"Flow Control is enabled on this deployment"}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.486+00:00"},"s":"I",  "c":"FTDC",     "id":20625,   "ctx":"initandlisten","msg":"Initializing full-time diagnostic data capture","attr":{"dataDirectory":"/data/db/diagnostic.data"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.495+00:00"},"s":"I",  "c":"NETWORK",  "id":23015,   "ctx":"listener","msg":"Listening on","attr":{"address":"/tmp/mongodb-27017.sock"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.495+00:00"},"s":"I",  "c":"NETWORK",  "id":23015,   "ctx":"listener","msg":"Listening on","attr":{"address":"0.0.0.0"}}
backend-mongodb-1  | {"t":{"$date":"2023-03-29T14:32:00.495+00:00"},"s":"I",  "c":"NETWORK",  "id":23016,   "ctx":"listener","msg":"Waiting for connections","attr":{"port":27017,"ssl":"off"}}
backend-app-1      |
backend-app-1      |   .   ____          _            __ _ _
backend-app-1      |  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
backend-app-1      | ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
backend-app-1      |  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
backend-app-1      |   '  |____| .__|_| |_|_| |_\__, | / / / /
backend-app-1      |  =========|_|==============|___/=/_/_/_/
backend-app-1      |  :: Spring Boot ::                (v3.0.4)
backend-app-1      |
backend-app-1      | 2023-03-29T14:32:00.821Z  INFO 1 --- [           main] c.j.backend.BackendApplication           : Starting BackendApplication v0.0.1-SNAPSHOT using Java 17.0.6 with PID 1 (/app/backend-0.0.1-SNAPSHOT.jar started by root in /app)
backend-app-1      | 2023-03-29T14:32:00.824Z  INFO 1 --- [           main] c.j.backend.BackendApplication           : No active profile set, falling back to 1 default profile: "default"
backend-app-1      | 2023-03-29T14:32:01.321Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data MongoDB repositories in DEFAULT mode.
backend-app-1      | 2023-03-29T14:32:01.343Z  INFO 1 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 18 ms. Found 0 MongoDB repository interfaces.
backend-app-1      | 2023-03-29T14:32:01.711Z  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
backend-app-1      | 2023-03-29T14:32:01.724Z  INFO 1 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
backend-app-1      | 2023-03-29T14:32:01.725Z  INFO 1 --- [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.5]
backend-app-1      | 2023-03-29T14:32:01.818Z  INFO 1 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
backend-app-1      | 2023-03-29T14:32:01.821Z  INFO 1 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 889 ms
backend-app-1      | 2023-03-29T14:32:02.267Z  INFO 1 --- [           main] org.mongodb.driver.client                : MongoClient with metadata {"driver": {"name": "mongo-java-driver|sync|spring-boot", "version": "4.8.2"}, "os": {"type": "Linux", "name": "Linux", "architecture": "amd64", "version": "6.2.8-arch1-1"}, "platform": "Java/Amazon.com Inc./17.0.6+10-LTS"} created with settings MongoClientSettings{readPreference=primary, writeConcern=WriteConcern{w=null, wTimeout=null ms, journal=null}, retryWrites=true, retryReads=true, readConcern=ReadConcern{level=null}, credential=null, streamFactoryFactory=null, commandListeners=[], codecRegistry=ProvidersCodecRegistry{codecProviders=[ValueCodecProvider{}, BsonValueCodecProvider{}, DBRefCodecProvider{}, DBObjectCodecProvider{}, DocumentCodecProvider{}, CollectionCodecProvider{}, IterableCodecProvider{}, MapCodecProvider{}, GeoJsonCodecProvider{}, GridFSFileCodecProvider{}, Jsr310CodecProvider{}, JsonObjectCodecProvider{}, BsonCodecProvider{}, EnumCodecProvider{}, com.mongodb.Jep395RecordCodecProvider@5dd91bca]}, clusterSettings={hosts=[localhost:27017], srvServiceName=mongodb, mode=SINGLE, requiredClusterType=UNKNOWN, requiredReplicaSetName='null', serverSelector='null', clusterListeners='[]', serverSelectionTimeout='30000 ms', localThreshold='30000 ms'}, socketSettings=SocketSettings{connectTimeoutMS=10000, readTimeoutMS=0, receiveBufferSize=0, sendBufferSize=0}, heartbeatSocketSettings=SocketSettings{connectTimeoutMS=10000, readTimeoutMS=10000, receiveBufferSize=0, sendBufferSize=0}, connectionPoolSettings=ConnectionPoolSettings{maxSize=100, minSize=0, maxWaitTimeMS=120000, maxConnectionLifeTimeMS=0, maxConnectionIdleTimeMS=0, maintenanceInitialDelayMS=0, maintenanceFrequencyMS=60000, connectionPoolListeners=[], maxConnecting=2}, serverSettings=ServerSettings{heartbeatFrequencyMS=10000, minHeartbeatFrequencyMS=500, serverListeners='[]', serverMonitorListeners='[]'}, sslSettings=SslSettings{enabled=false, invalidHostNameAllowed=false, context=null}, applicationName='null', compressorList=[], uuidRepresentation=JAVA_LEGACY, serverApi=null, autoEncryptionSettings=null, contextProvider=null}
backend-app-1      | 2023-03-29T14:32:02.265Z  INFO 1 --- [localhost:27017] org.mongodb.driver.cluster               : Exception in monitor thread while connecting to server localhost:27017
backend-app-1      |
backend-app-1      | com.mongodb.MongoSocketOpenException: Exception opening socket
backend-app-1      | 	at com.mongodb.internal.connection.SocketStream.open(SocketStream.java:73) ~[mongodb-driver-core-4.8.2.jar!/:na]
backend-app-1      | 	at com.mongodb.internal.connection.InternalStreamConnection.open(InternalStreamConnection.java:183) ~[mongodb-driver-core-4.8.2.jar!/:na]
backend-app-1      | 	at com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitorRunnable.lookupServerDescription(DefaultServerMonitor.java:198) ~[mongodb-driver-core-4.8.2.jar!/:na]
backend-app-1      | 	at com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitorRunnable.run(DefaultServerMonitor.java:158) ~[mongodb-driver-core-4.8.2.jar!/:na]
backend-app-1      | 	at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]
backend-app-1      | Caused by: java.net.ConnectException: Connection refused
backend-app-1      | 	at java.base/sun.nio.ch.Net.pollConnect(Native Method) ~[na:na]
backend-app-1      | 	at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:672) ~[na:na]
backend-app-1      | 	at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:542) ~[na:na]
backend-app-1      | 	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:597) ~[na:na]
backend-app-1      | 	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327) ~[na:na]
backend-app-1      | 	at java.base/java.net.Socket.connect(Socket.java:633) ~[na:na]
backend-app-1      | 	at com.mongodb.internal.connection.SocketStreamHelper.initialize(SocketStreamHelper.java:107) ~[mongodb-driver-core-4.8.2.jar!/:na]
backend-app-1      | 	at com.mongodb.internal.connection.SocketStream.initializeSocket(SocketStream.java:82) ~[mongodb-driver-core-4.8.2.jar!/:na]
backend-app-1      | 	at com.mongodb.internal.connection.SocketStream.open(SocketStream.java:68) ~[mongodb-driver-core-4.8.2.jar!/:na]
backend-app-1      | 	... 4 common frames omitted
backend-app-1      |
backend-app-1      | 2023-03-29T14:32:02.479Z  INFO 1 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
backend-app-1      | 2023-03-29T14:32:02.499Z  INFO 1 --- [           main] c.j.backend.BackendApplication           : Started BackendApplication in 2.183 seconds (process running for 2.68)
^CGracefully stopping... (press Ctrl+C again to force)
Aborting on container exit...
[+] Running 2/2
 ✔ Container backend-app-1      Stopped                                                                                                                                                                                               0.4s
 ✔ Container backend-mongodb-1  Stopped                                                                                                                                                                                               0.4s
canceled
```